### PR TITLE
More repliant and support "callout in callout"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.idea/*
+environment.yml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 mkdocs>=1
+pytest>=7.1.2

--- a/src/mkdocs_callouts/plugin.py
+++ b/src/mkdocs_callouts/plugin.py
@@ -28,7 +28,6 @@ class CalloutsPlugin(BasePlugin):
 
     def on_page_markdown(self, markdown, page, config, files):
         # #save-the-cycles
-
         if not re.search(r'> ?\[!', markdown):
             return markdown
 
@@ -52,7 +51,7 @@ class CalloutsPlugin(BasePlugin):
                 contents = parse_callout_title(line, nb_space)
             elif line.startswith('>') and is_callout:
                 # parse callout contents
-                contents = re.sub('> ?', '\t', line)  # tabulation = 4 space (cf material documentation)
+                contents = re.sub('> ?', '\t', line)
             elif is_callout:
                 # no callout anymore
                 is_callout = False

--- a/src/mkdocs_callouts/utils.py
+++ b/src/mkdocs_callouts/utils.py
@@ -1,23 +1,18 @@
-def parse_callout(suffix):
-    """
-    Returns proper syntax and title for the callout block.
-    Expected results are ['!!!', title] or ['???'|'???+', title]
-    """
-    syntax = '!!!'
-    title = suffix
-    # Check if the first character of the
-    # suffix defines a foldable callout.
-    # Lastly remove the leading space from title
-    try:
-        if title[0] == '-':
-            syntax = '???'
-            title = title[1:]
-        if title[0] == '+':
-            syntax = '???+'
-            title = title[1:]
-        # Remove leading space
-        title = title[1:]
-    # If title is empty, do nothing.
-    except IndexError:
-        pass
-    return syntax, title
+import re
+
+
+def parse_callout_title(line: str, nb: int):
+    title = re.search(r'^( ?>*)*\[!(.*)\]', line)
+    rest_line = re.sub(r'^( ?>*)*\[!(.*)\][\+\-]?', '', line)
+    title = title.group(2).lower()
+    if ']-' in line:
+        title = '??? ' + title
+    elif ']+' in line:
+        title = '???+ ' + title
+    else:
+        title = '!!! ' + title
+    if len(rest_line) > 1:
+        title = title + ' "' + rest_line.strip() + '"'
+    if nb > 1:
+        title = '\t' * nb + title
+    return title

--- a/src/mkdocs_callouts/utils.py
+++ b/src/mkdocs_callouts/utils.py
@@ -14,5 +14,5 @@ def parse_callout_title(line: str, nb: int):
     if len(rest_line) > 1:
         title = title + ' "' + rest_line.strip() + '"'
     if nb > 1:
-        title = '\t' * nb + title
+        title = '\t' * (nb-1) + title
     return title

--- a/src/mkdocs_callouts/utils.py
+++ b/src/mkdocs_callouts/utils.py
@@ -14,5 +14,5 @@ def parse_callout_title(line: str, nb: int):
     if len(rest_line) > 1:
         title = title + ' "' + rest_line.strip() + '"'
     if nb > 1:
-        title = '\t' * (nb-1) + title
+        title = '\t' * nb + title
     return title

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -37,7 +37,7 @@ def test_on_page_markdown(plugin):
 
     # test multiple callouts
     test_markdown = '> [!INFO]-\n> Folded content\n>>[!INFO]+\n>> Folded content'
-    assert ('??? info\n\tFolded content\n\t\t???+ info\n\t\tFolded content\n'
+    assert ('??? info\n\tFolded content\n\t???+ info\n\t\tFolded content\n'
             in plugin.on_page_markdown(test_markdown, None, None, None))
 
     test_markdown = '> [!INFO]-\n> Folded content'

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -12,37 +12,46 @@ def plugin():
 def test_on_page_markdown(plugin):
     # Test untitled block
     test_markdown = '> [!INFO]\n> Unitled block'
-    assert ('!!! info ""\n    Unitled block'
+    assert ('!!! info\n\tUnitled block'
             in plugin.on_page_markdown(test_markdown, None, None, None))
 
     # Test regular titled block
     test_markdown = '> [!INFO] Title\n> Titled block\n> Two lines'
-    assert ('!!! info "Title"\n    Titled block\n    Two lines'
+    assert ('!!! info "Title"\n\tTitled block\n\tTwo lines'
             in plugin.on_page_markdown(test_markdown, None, None, None))
 
     # Test folded block, closed by default
     test_markdown = '> [!INFO]- Folded block\n> Folded content'
-    assert ('??? info "Folded block"\n    Folded content'
+    assert ('??? info "Folded block"\n\tFolded content'
             in plugin.on_page_markdown(test_markdown, None, None, None))
 
     # Test folded block, open by default
     test_markdown = '> [!INFO]+ Folded block\n> Folded content'
-    assert ('???+ info "Folded block"\n    Folded content'
+    assert ('???+ info "Folded block"\n\tFolded content'
             in plugin.on_page_markdown(test_markdown, None, None, None))
 
     # Test folded block, closed by default, untitled
     test_markdown = '> [!INFO]-\n> Folded content'
-    assert ('??? info ""\n    Folded content'
+    assert ('??? info\n\tFolded content'
+            in plugin.on_page_markdown(test_markdown, None, None, None))
+
+    # test multiple callouts
+    test_markdown = '> [!INFO]-\n> Folded content\n>>[!INFO]+\n>> Folded content'
+    assert ('??? info\n\tFolded content\n\t\t???+ info\n\t\tFolded content\n'
+            in plugin.on_page_markdown(test_markdown, None, None, None))
+
+    test_markdown = '> [!INFO]-\n> Folded content'
+    assert ('??? info\n\tFolded content'
             in plugin.on_page_markdown(test_markdown, None, None, None))
 
     # Test folded block, open by default, untitled
     test_markdown = '> [!INFO]+\n> Folded content'
-    assert ('???+ info ""\n    Folded content'
+    assert ('???+ info\n\tFolded content\n'
             in plugin.on_page_markdown(test_markdown, None, None, None))
 
     # Test non-callout blocks
-    test_markdown = '> [!NOTE] Callout\n> Callout Text\nSome text\n> Block'
-    assert ('!!! note "Callout"\n    Callout Text\nSome text\n> Block'
+    test_markdown = '> [!custom] Callout\n> Callout Text\nSome text\n> Block'
+    assert ('!!! custom "Callout"\n\tCallout Text\nSome text\n> Block'
             in plugin.on_page_markdown(test_markdown, None, None, None))
 
     # Test wikilink


### PR DESCRIPTION
Hello.
I updated your code with my method for detecting callout. This method is more repliant to detect callout, because Obsidian accept callout starting like : `>[!` (note the absence's whitespace) and `>contents`.

Also, I updated the plugin to support "callout in callout" : 
![image](https://user-images.githubusercontent.com/30244939/175906850-1f3bec5d-6699-4dba-ba58-fdec960045f1.png)

With : 
```md
> [!info] notes
> somes contents
>> [!info] new admonition
>> contents of admonition2
```
This will be transform with : 
```md
!!! info "notes"
    some contents
    !!! info "new admonition"
        contents of admonition 2
```

Also, I changed the four space for tabulation, for a better reading. 
