### PR TITLE
Better nested callout handling, supports spaces after

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,12 @@ plugins:
   - callouts:
       aliases: false
 ```
+
+### Breakless lists (New in 1.11.0)
+Markdown specification requires a blank line between list items and other block elements, whereas Obsidian does not require this. This plugin will by default automatically add a blank line between list items and callout blocks (if none are present). Should you wish to disable this behaviour then you can do so by setting `breakless_lists` to `false` in the plugin configuration:
+```yaml
+plugins:
+  - search
+  - callouts:
+      breakless_lists: false
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mkdocs-callouts"
-version = "1.10.0"
+version = "1.11.0"
 keywords = ["mkdocs", "mkdocs-plugin", "markdown", "callouts", "admonitions", "obsidian"]
 description = "A simple plugin that converts Obsidian style callouts and converts them into mkdocs supported 'admonitions' (a.k.a. callouts)."
 readme = "README.md"

--- a/src/mkdocs_callouts/plugin.py
+++ b/src/mkdocs_callouts/plugin.py
@@ -18,11 +18,13 @@ class CalloutsPlugin(BasePlugin):
            with confidence using Obsidian.
     """
     config_scheme = {  # pragma: no cover
-        ('aliases', config_options.Type(bool, default=True))
+        ('aliases', config_options.Type(bool, default=True)),
+        ('breakless_lists', config_options.Type(bool, default=True))
     }
 
     def on_page_markdown(self, markdown, page, config, files):
         parser = CalloutParser(
-            convert_aliases=self.config.get('aliases', True)
+            convert_aliases=self.config.get('aliases', True),
+            breakless_lists=self.config.get('breakless_lists', True)
         )
         return parser.parse(markdown)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -215,3 +215,27 @@ def test_nested_callouts_with_blockquotes():
     mkdown = '> [!INFO]\n> > [!INFO]\n> text\n> > blockquote'
     result = '!!! info\n\t!!! info\n\ttext\n\t> blockquote'
     assert (parser.parse(mkdown) == result)
+
+
+def test_breakless_lists():
+    parser = CalloutParser(convert_aliases=True, breakless_lists=False)
+
+    mkdown = '> [!INFO]\n> text\n> - item 1\n> - item 2'
+    result = '!!! info\n\ttext\n\t- item 1\n\t- item 2'
+    assert (parser.parse(mkdown) == result)
+
+    parser = CalloutParser(convert_aliases=True, breakless_lists=True)
+
+    mkdown = '> [!INFO]\n> text\n> - item 1\n> - item 2'
+    result = '!!! info\n\ttext\n\t\n\t- item 1\n\t- item 2'
+    assert (parser.parse(mkdown) == result)
+
+    # Shouldn't interfere with standard lists following the correct syntax
+    mkdown = '> [!INFO]\n>\n> - item 1\n> - item 2\n> text'
+    result = '!!! info\n\t\n\t- item 1\n\t- item 2\n\ttext'
+    assert (parser.parse(mkdown) == result)
+
+    # Nested callouts
+    mkdown = '> [!INFO]\n> > [!INFO]\n> > text\n> > - item 1\n> > - item 2\n> text\n> - item 1\n> - item 2'
+    result = '!!! info\n\t!!! info\n\t\ttext\n\t\t\n\t\t- item 1\n\t\t- item 2\n\ttext\n\t\n\t- item 1\n\t- item 2'
+    assert (parser.parse(mkdown) == result)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -186,3 +186,32 @@ def test_aliases_disabled():
     result = '!!! hint\n\tText'
     assert (parser.parse(mkdown) == result)
     assert (parser.parse(mkdown) != unexpected)
+
+
+def test_nested_callouts_with_spaces():
+    parser = CalloutParser(convert_aliases=True)
+
+    mkdown = '> [!INFO]\n> > [!INFO]'
+    result = '!!! info\n\t!!! info'
+    assert (parser.parse(mkdown) == result)
+
+
+    mkdown = '> [!INFO]\n> > [!INFO] Title\n> > > [!INFO]\n> [!INFO]\n > [!INFO]'
+    result = '!!! info\n\t!!! info "Title"\n\t\t!!! info\n!!! info\n!!! info'
+    assert (parser.parse(mkdown) == result)
+
+
+def test_nested_callouts_with_blockquotes():
+    parser = CalloutParser(convert_aliases=True)
+
+    mkdown = '> [!INFO]\n> > blockquote'
+    result = '!!! info\n\t> blockquote'
+    assert (parser.parse(mkdown) == result)
+
+    mkdown = '> [!INFO]\n> > blockquote\n> > > blockquote'
+    result = '!!! info\n\t> blockquote\n\t> > blockquote'
+    assert (parser.parse(mkdown) == result)
+
+    mkdown = '> [!INFO]\n> > [!INFO]\n> text\n> > blockquote'
+    result = '!!! info\n\t!!! info\n\ttext\n\t> blockquote'
+    assert (parser.parse(mkdown) == result)


### PR DESCRIPTION
Fixes #7 

These changes support whitespace after the leading `>` symbols while maintaining blockquote compatability by storing the indent hierarchy in a list instead of a bool.