### PR TITLE
Bugfix + don't convert callouts within codefences

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mkdocs-callouts"
-version = "1.11.1"
+version = "1.12.0"
 keywords = ["mkdocs", "mkdocs-plugin", "markdown", "callouts", "admonitions", "obsidian"]
 description = "A simple plugin that converts Obsidian style callouts and converts them into mkdocs supported 'admonitions' (a.k.a. callouts)."
 readme = "README.md"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -244,3 +244,32 @@ def test_breakless_lists():
     mkdown = '> [!INFO]\n> text\n> 1. item 1\n> 2. item 2'
     result = '!!! info\n\ttext\n\t\n\t1. item 1\n\t2. item 2'
     assert (parser.parse(mkdown) == result)
+
+def test_edgecase_in_nested_callouts():
+    # Go from 1, 2, 3 callouts back to 1
+    mkdown = '> [!INFO]\n> > [!INFO]\n> > > [!INFO]\n> > > Text\n> Text'
+    result = '!!! info\n\t!!! info\n\t\t!!! info\n\t\t\tText\n\tText'
+    assert (convert(mkdown) == result)
+
+def test_callout_in_codeblocks():
+    mkdown = '```markdown\n> [!INFO]\n> Text\n```'
+    assert (convert(mkdown) == mkdown)
+
+    # Edgecase where the callout might continue after a codeblock
+    mkdown = '> [!INFO]\n```\n> code\n```\n> Text'
+    result = '!!! info\n```\n> code\n```\n> Text'
+    assert (convert(mkdown) == result)
+
+    mkdown = '> [!INFO]\n```\n> code\n```\n> Blockquote\n> [!INFO]\n> Text'
+    result = '!!! info\n```\n> code\n```\n> Blockquote\n!!! info\n\tText'
+    assert (convert(mkdown) == result)
+
+
+@pytest.mark.xfail
+def test_callout_in_codeblocks_within_callout():
+    # A codefence within a callout containing a callout will still be converted
+    # Though it's probably not worth the effort to handle this edgecase in the parser
+    # Given how unlikely it is to occur in practice
+    mkdown = '> [!INFO]\n> ```\n> [!INFO]\n> ```'
+    result = '!!! info\n\t```\n> [!INFO]\n\t```'
+    assert (convert(mkdown) == result)


### PR DESCRIPTION
This would previously not work:

```md
> [!INFO]
> > [!INFO]
> > > [!INFO]
> Text
```

because the indent block would jump from 3 to 2, not 1. This is now fixed by using a `while` statement instead of an `if`.

Also no longer converts callouts within codefences, should you need to display the syntax within a codeblock.

```md
Callout Syntax:
```md
> [!INFO]
> Text goes here
\```
```