### PR TITLE
Hotfix/fix incorrect spacing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mkdocs-callouts"
-version = "1.14.0"
+version = "1.14.1"
 keywords = ["mkdocs", "mkdocs-plugin", "markdown", "callouts", "admonitions", "obsidian"]
 description = "A simple plugin that converts Obsidian style callouts and converts them into mkdocs supported 'admonitions' (a.k.a. callouts)."
 readme = "README.md"

--- a/src/mkdocs_callouts/utils.py
+++ b/src/mkdocs_callouts/utils.py
@@ -182,7 +182,7 @@ class CalloutParser:
                 f"{whitespace}{self._get_indent(indent_level=max(self.indent_levels))}"
             )
 
-            line = re.sub(rf"^\s*(?:> ?){{{self.indent_levels[-1]}}} ?", indent, line)
+            line = re.sub(rf"^\s*(?:> ?){{{self.indent_levels[-1]}}}", indent, line)
 
             # Handle breakless lists before returning the line, if enabled
             if self.breakless_lists:


### PR DESCRIPTION
Resolves #20 

No longer removes an additional (optional) trailing whitespace

## Input Markdown

```md
> [!INFO]
> ```python
> def test():
>     print("Test")
> ```
```

## Old output inside callout

```python
def test():
   print("Test")
```

## New output inside callout

```python
def test():
    print("Test")
``` 