### PR TITLE
feat: fallback to alias as a title when using aliases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mkdocs-callouts"
-version = "1.14.1"
+version = "1.15.0"
 keywords = ["mkdocs", "mkdocs-plugin", "markdown", "callouts", "admonitions", "obsidian"]
 description = "A simple plugin that converts Obsidian style callouts and converts them into mkdocs supported 'admonitions' (a.k.a. callouts)."
 readme = "README.md"

--- a/src/mkdocs_callouts/utils.py
+++ b/src/mkdocs_callouts/utils.py
@@ -87,6 +87,9 @@ class CalloutParser:
 
         # Group 3: Callout block type (note, warning, info, etc.) + inline block syntax
         c_type = block.group(3).lower()
+        # Get a clean version of the callout type for the title, if it exists in order
+        # to use it as a fallback if the title is empty & we are using an alias
+        clean_c_type = c_type.split("|")[0].strip()
         c_type = re.sub(r" *\| *(inline|left) *$", " inline", c_type)
         c_type = re.sub(r" *\| *(inline end|right) *$", " inline end", c_type)
         c_type = re.sub(r" *\|.*", "", c_type)
@@ -100,6 +103,10 @@ class CalloutParser:
 
         # Group 5: Title, add leading whitespace and quotation marks, if it exists
         title = block.group(5).strip()
+        # If we are using an alias without a title, use the alias
+        # We use startswith to avoid issues with the inline block syntax
+        if not title and not c_type.lower().startswith(clean_c_type.lower()):
+            title = clean_c_type.capitalize()
         title = f' "{title}"' if title else ""
 
         # Construct the new callout syntax ({indent}!!! note "Title")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -146,12 +146,12 @@ def test_aliases_enabled():
 
     # Test alias conversion
     mkdown = '> [!HINT]\n> Text'
-    result = '!!! tip\n\tText'
+    result = '!!! tip "Hint"\n\tText'
     assert (parser.parse(mkdown) == result)
 
     # Test alias conversion with inline block syntax
     mkdown = '> [!HINT | inline]\n> Text'
-    result = '!!! tip inline\n\tText'
+    result = '!!! tip inline "Hint"\n\tText'
     assert (parser.parse(mkdown) == result)
 
     # Test alias conversion where alias is a substring of another alias
@@ -403,3 +403,35 @@ def test_nested_codefences():
 > ```
 ```"""
     assert (convert(mkdown) == mkdown)
+
+
+def test_alias_titles():
+    # Test alias titles
+    mkdown = "> [!cAuTiON]"
+    result = "!!! warning \"Caution\""
+
+    assert (convert(mkdown) == result)
+
+    # Test normal titles
+    mkdown = "> [!WARNING]"
+    result = "!!! warning"
+
+    assert (convert(mkdown) == result)
+
+    # Test with inline block syntax
+    mkdown = "> [!WaRnINg | inline]"
+    result = "!!! warning inline"
+
+    assert (convert(mkdown) == result)
+
+    # Test alias titles with inline block syntax
+    mkdown = "> [!cAuTiON | inline]"
+    result = "!!! warning inline \"Caution\""
+
+    assert (convert(mkdown) == result)
+
+    # Test alias with a title
+    mkdown = "> [!cAuTiON] Title"
+    result = "!!! warning \"Title\""
+
+    assert (convert(mkdown) == result)


### PR DESCRIPTION
Adds support for #22

Expected behavior:
```md
> [!CAUTION]
=====================
!!! warning "Caution"
```

```md
> [!CAUTION] Title
=====================
!!! warning "Title"
```

```md
> [!WARNING]
=====================
!!! warning
```